### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/finger-gun/sisu/security/code-scanning/1](https://github.com/finger-gun/sisu/security/code-scanning/1)

To fix the problem, add a `permissions` key to the workflow to reduce the available token privileges to the minimum required. The most conservative and general approach, per GitHub recommendations, is to set `permissions: contents: read` at the workflow root. This setting applies to all jobs in the workflow, limiting the GITHUB_TOKEN to read-only access to repository contents unless overridden elsewhere. This covers the needs of the described CI steps (checkout, install, test, upload-artifact) without granting unnecessary write access. 

The best way to implement this fix is to add the following block right after the `name:` line (line 1):

```yaml
permissions:
  contents: read
```

No other changes are necessary, since none of the steps in the workflow need write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
