### PR TITLE
fix: add robots.txt compliance and respectRobots option in web-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,208 +27,245 @@
       }
     },
     "examples/ollama-hello": {
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
-        "@sisu-ai/adapter-ollama": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/mw-usage-tracker": "1.0.1",
+        "@sisu-ai/adapter-ollama": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/mw-usage-tracker": "2.0.0",
         "dotenv": "^16.4.5"
       }
     },
     "examples/ollama-weather": {
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
-        "@sisu-ai/adapter-ollama": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-control-flow": "1.0.1",
-        "@sisu-ai/mw-conversation-buffer": "1.0.1",
-        "@sisu-ai/mw-error-boundary": "1.0.1",
-        "@sisu-ai/mw-guardrails": "1.0.1",
-        "@sisu-ai/mw-invariants": "1.0.1",
-        "@sisu-ai/mw-react-parser": "1.0.1",
-        "@sisu-ai/mw-register-tools": "1.0.1",
-        "@sisu-ai/mw-tool-calling": "1.0.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/mw-usage-tracker": "1.0.1",
+        "@sisu-ai/adapter-ollama": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-control-flow": "2.0.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-guardrails": "2.0.0",
+        "@sisu-ai/mw-invariants": "2.0.0",
+        "@sisu-ai/mw-react-parser": "2.0.0",
+        "@sisu-ai/mw-register-tools": "2.0.0",
+        "@sisu-ai/mw-tool-calling": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/mw-usage-tracker": "2.0.0",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"
       }
     },
     "examples/ollama-web-search": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@sisu-ai/adapter-ollama": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-conversation-buffer": "1.0.1",
-        "@sisu-ai/mw-error-boundary": "1.0.1",
-        "@sisu-ai/mw-register-tools": "1.0.1",
-        "@sisu-ai/mw-tool-calling": "1.0.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/tool-web-search-duckduckgo": "0.1.0",
+        "@sisu-ai/adapter-ollama": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-register-tools": "2.0.0",
+        "@sisu-ai/mw-tool-calling": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/tool-web-search-duckduckgo": "1.0.0",
         "dotenv": "^16.4.5"
       }
     },
     "examples/openai-branch": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-control-flow": "1.0.1",
-        "@sisu-ai/mw-conversation-buffer": "1.0.1",
-        "@sisu-ai/mw-error-boundary": "1.0.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/mw-usage-tracker": "1.0.1",
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-control-flow": "2.0.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/mw-usage-tracker": "2.0.0",
         "dotenv": "^16.4.5"
       }
     },
     "examples/openai-control-flow": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-control-flow": "1.0.1",
-        "@sisu-ai/mw-conversation-buffer": "1.0.1",
-        "@sisu-ai/mw-error-boundary": "1.0.1",
-        "@sisu-ai/mw-invariants": "1.0.1",
-        "@sisu-ai/mw-register-tools": "1.0.1",
-        "@sisu-ai/mw-tool-calling": "1.0.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/mw-usage-tracker": "1.0.1",
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-control-flow": "2.0.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-invariants": "2.0.0",
+        "@sisu-ai/mw-register-tools": "2.0.0",
+        "@sisu-ai/mw-tool-calling": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/mw-usage-tracker": "2.0.0",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"
       }
     },
-    "examples/openai-graph": {
-      "version": "0.1.2",
+    "examples/openai-github-projects": {
+      "extraneous": true
+    },
+    "examples/openai-google-search": {
+      "version": "0.1.0",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-control-flow": "1.0.1",
-        "@sisu-ai/mw-conversation-buffer": "1.0.1",
-        "@sisu-ai/mw-error-boundary": "1.0.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/mw-usage-tracker": "1.0.1",
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-register-tools": "2.0.0",
+        "@sisu-ai/mw-tool-calling": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/tool-summarize-text": "1.0.0",
+        "@sisu-ai/tool-web-fetch": "1.0.0",
+        "@sisu-ai/tool-web-search-google": "1.0.0",
+        "dotenv": "^16.4.5"
+      }
+    },
+    "examples/openai-graph": {
+      "version": "0.2.0",
+      "dependencies": {
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-control-flow": "2.0.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/mw-usage-tracker": "2.0.0",
         "dotenv": "^16.4.5"
       }
     },
     "examples/openai-guardrails": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-conversation-buffer": "1.0.1",
-        "@sisu-ai/mw-error-boundary": "1.0.1",
-        "@sisu-ai/mw-guardrails": "1.0.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/mw-usage-tracker": "1.0.1",
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-guardrails": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/mw-usage-tracker": "2.0.0",
         "dotenv": "^16.4.5"
       }
     },
     "examples/openai-hello": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/mw-usage-tracker": "1.0.1",
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/mw-usage-tracker": "2.0.0",
         "dotenv": "^16.4.5"
       }
     },
     "examples/openai-parallel": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-control-flow": "1.0.1",
-        "@sisu-ai/mw-conversation-buffer": "1.0.1",
-        "@sisu-ai/mw-error-boundary": "1.0.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/mw-usage-tracker": "1.0.1",
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-control-flow": "2.0.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/mw-usage-tracker": "2.0.0",
+        "dotenv": "^16.4.5"
+      }
+    },
+    "examples/openai-plan-act": {
+      "version": "0.1.0",
+      "dependencies": {
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-context-compressor": "1.0.0",
+        "@sisu-ai/mw-control-flow": "2.0.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-register-tools": "2.0.0",
+        "@sisu-ai/mw-tool-calling": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/tool-summarize-text": "1.0.0",
+        "@sisu-ai/tool-web-fetch": "1.0.0",
+        "@sisu-ai/tool-wikipedia": "1.0.0",
         "dotenv": "^16.4.5"
       }
     },
     "examples/openai-react": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-conversation-buffer": "1.0.1",
-        "@sisu-ai/mw-error-boundary": "1.0.1",
-        "@sisu-ai/mw-react-parser": "1.0.1",
-        "@sisu-ai/mw-register-tools": "1.0.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/mw-usage-tracker": "1.0.1",
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-react-parser": "2.0.0",
+        "@sisu-ai/mw-register-tools": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/mw-usage-tracker": "2.0.0",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"
       }
     },
     "examples/openai-vision": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/mw-usage-tracker": "1.0.1",
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/mw-usage-tracker": "2.0.0",
         "dotenv": "^16.4.5"
       }
     },
     "examples/openai-weather": {
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-control-flow": "1.0.1",
-        "@sisu-ai/mw-conversation-buffer": "1.0.1",
-        "@sisu-ai/mw-error-boundary": "1.0.1",
-        "@sisu-ai/mw-invariants": "1.0.1",
-        "@sisu-ai/mw-register-tools": "1.0.1",
-        "@sisu-ai/mw-tool-calling": "1.0.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/mw-usage-tracker": "1.0.1",
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-control-flow": "2.0.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-invariants": "2.0.0",
+        "@sisu-ai/mw-register-tools": "2.0.0",
+        "@sisu-ai/mw-tool-calling": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/mw-usage-tracker": "2.0.0",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"
       }
     },
     "examples/openai-web-fetch": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-conversation-buffer": "1.0.1",
-        "@sisu-ai/mw-error-boundary": "1.0.1",
-        "@sisu-ai/mw-register-tools": "1.0.1",
-        "@sisu-ai/mw-tool-calling": "1.0.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/tool-web-fetch": "0.1.0",
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-register-tools": "2.0.0",
+        "@sisu-ai/mw-tool-calling": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/tool-web-fetch": "1.0.0",
         "dotenv": "^16.4.5"
       }
     },
     "examples/openai-web-search": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-conversation-buffer": "1.0.1",
-        "@sisu-ai/mw-error-boundary": "1.0.1",
-        "@sisu-ai/mw-register-tools": "1.0.1",
-        "@sisu-ai/mw-tool-calling": "1.0.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/tool-web-search-openai": "0.1.0",
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-register-tools": "2.0.0",
+        "@sisu-ai/mw-tool-calling": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/tool-web-search-openai": "1.0.0",
         "dotenv": "^16.4.5"
       }
     },
     "examples/openai-wikipedia": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "1.0.1",
-        "@sisu-ai/core": "0.2.1",
-        "@sisu-ai/mw-conversation-buffer": "1.0.1",
-        "@sisu-ai/mw-error-boundary": "1.0.1",
-        "@sisu-ai/mw-register-tools": "1.0.1",
-        "@sisu-ai/mw-tool-calling": "1.0.1",
-        "@sisu-ai/mw-trace-viewer": "1.0.1",
-        "@sisu-ai/tool-wikipedia": "0.1.0",
+        "@sisu-ai/adapter-openai": "2.0.0",
+        "@sisu-ai/core": "0.3.0",
+        "@sisu-ai/mw-conversation-buffer": "2.0.0",
+        "@sisu-ai/mw-error-boundary": "2.0.0",
+        "@sisu-ai/mw-register-tools": "2.0.0",
+        "@sisu-ai/mw-tool-calling": "2.0.0",
+        "@sisu-ai/mw-trace-viewer": "2.0.0",
+        "@sisu-ai/tool-wikipedia": "1.0.0",
         "dotenv": "^16.4.5"
       }
     },
@@ -242,15 +279,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@ampproject/remapping/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -305,8 +333,6 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -533,78 +559,17 @@
         "node": ">=12"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
-      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
-      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
-      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
-      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
-      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
       "cpu": [
         "arm64"
       ],
@@ -613,363 +578,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
-      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
-      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
-      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
-      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
-      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
-      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
-      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
-      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
-      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
-      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
-      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
-      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
-      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
-      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
-      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
-      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -1053,15 +661,6 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
-    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "dev": true,
@@ -1076,12 +675,12 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
+      "version": "0.3.30",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@manypkg/find-root": {
@@ -1185,38 +784,8 @@
         "node": ">=14"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz",
-      "integrity": "sha512-lVgpeQyy4fWN5QYebtW4buT/4kn4p4IJ+kDNB4uYNT5b8c8DLJDg6titg20NIg7E8RWwdWZORW6vUFfrLyG3KQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz",
-      "integrity": "sha512-2O73dR4Dc9bp+wSYhviP6sDziurB5/HCym7xILKifWdE9UsOe2FtNcM+I4xZjKrfLJnq5UR8k9riB87gauiQtw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz",
-      "integrity": "sha512-vwSXQN8T4sKf1RHr1F0s98Pf8UPz7pS6P3LG9NSmuw0TVh7EmaE+5Ny7hJOZ0M2yuTctEsHHRTMi2wuHkdS6Hg==",
       "cpu": [
         "arm64"
       ],
@@ -1225,258 +794,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz",
-      "integrity": "sha512-cQp/WG8HE7BCGyFVuzUg0FNmupxC+EPZEwWu2FCGGw5WDT1o2/YlENbm5e9SMvfDFR6FRhVCBePLqj0o8MN7Vw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz",
-      "integrity": "sha512-UR1uTJFU/p801DvvBbtDD7z9mQL8J80xB0bR7DqW7UGQHRm/OaKzp4is7sQSdbt2pjjSS72eAtRh43hNduTnnQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz",
-      "integrity": "sha512-G/DKyS6PK0dD0+VEzH/6n/hWDNPDZSMBmqsElWnCRGrYOb2jC0VSupp7UAHHQ4+QILwkxSMaYIbQ72dktp8pKA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz",
-      "integrity": "sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz",
-      "integrity": "sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz",
-      "integrity": "sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz",
-      "integrity": "sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz",
-      "integrity": "sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz",
-      "integrity": "sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz",
-      "integrity": "sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz",
-      "integrity": "sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz",
-      "integrity": "sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz",
-      "integrity": "sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz",
-      "integrity": "sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz",
-      "integrity": "sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz",
-      "integrity": "sha512-q7cIIdFvWQoaCbLDUyUc8YfR3Jh2xx3unO8Dn6/TTogKjfwrax9SyfmGGK6cQhKtjePI7jRfd7iRYcxYs93esg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz",
-      "integrity": "sha512-XzNOVg/YnDOmFdDKcxxK410PrcbcqZkBmz+0FicpW5jtjKQxcW1BZJEQOF0NJa6JO7CZhett8GEtRN/wYLYJuw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz",
-      "integrity": "sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@sisu-ai/adapter-ollama": {
@@ -1489,6 +806,10 @@
     },
     "node_modules/@sisu-ai/core": {
       "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@sisu-ai/mw-context-compressor": {
+      "resolved": "packages/middleware/context-compressor",
       "link": true
     },
     "node_modules/@sisu-ai/mw-control-flow": {
@@ -1531,12 +852,20 @@
       "resolved": "packages/middleware/usage-tracker",
       "link": true
     },
+    "node_modules/@sisu-ai/tool-summarize-text": {
+      "resolved": "packages/tools/summarize-text",
+      "link": true
+    },
     "node_modules/@sisu-ai/tool-web-fetch": {
       "resolved": "packages/tools/web-fetch",
       "link": true
     },
     "node_modules/@sisu-ai/tool-web-search-duckduckgo": {
       "resolved": "packages/tools/web-search-duckduckgo",
+      "link": true
+    },
+    "node_modules/@sisu-ai/tool-web-search-google": {
+      "resolved": "packages/tools/web-search-google",
       "link": true
     },
     "node_modules/@sisu-ai/tool-web-search-openai": {
@@ -1569,8 +898,6 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1579,15 +906,11 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1601,8 +924,6 @@
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1635,8 +956,6 @@
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1652,8 +971,6 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1679,8 +996,6 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1692,8 +1007,6 @@
     },
     "node_modules/@vitest/runner": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1707,8 +1020,6 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1722,8 +1033,6 @@
     },
     "node_modules/@vitest/spy": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1735,8 +1044,6 @@
     },
     "node_modules/@vitest/utils": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1820,8 +1127,6 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1830,25 +1135,12 @@
     },
     "node_modules/ast-v8-to-istanbul": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.5.tgz",
-      "integrity": "sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.30",
         "estree-walker": "^3.0.3",
         "js-tokens": "^9.0.1"
-      }
-    },
-    "node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/balanced-match": {
@@ -1888,8 +1180,6 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1898,8 +1188,6 @@
     },
     "node_modules/chai": {
       "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1920,8 +1208,6 @@
     },
     "node_modules/check-error": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1994,8 +1280,6 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2063,15 +1347,11 @@
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
-      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2124,8 +1404,6 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2134,8 +1412,6 @@
     },
     "node_modules/expect-type": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
-      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2223,10 +1499,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2423,15 +1696,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.30",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "dev": true,
@@ -2460,8 +1724,6 @@
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2503,8 +1765,6 @@
     },
     "node_modules/loupe": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2515,8 +1775,6 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.18",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
-      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2609,8 +1867,6 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -2646,6 +1902,10 @@
       "resolved": "examples/openai-control-flow",
       "link": true
     },
+    "node_modules/openai-google-search": {
+      "resolved": "examples/openai-google-search",
+      "link": true
+    },
     "node_modules/openai-graph": {
       "resolved": "examples/openai-graph",
       "link": true
@@ -2660,6 +1920,10 @@
     },
     "node_modules/openai-parallel": {
       "resolved": "examples/openai-parallel",
+      "link": true
+    },
+    "node_modules/openai-plan-act": {
+      "resolved": "examples/openai-plan-act",
       "link": true
     },
     "node_modules/openai-react": {
@@ -2797,15 +2061,11 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2838,8 +2098,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "funding": [
         {
@@ -2946,8 +2204,6 @@
     },
     "node_modules/rollup": {
       "version": "4.50.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz",
-      "integrity": "sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3044,8 +2300,6 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
     },
@@ -3092,15 +2346,11 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3197,8 +2447,6 @@
     },
     "node_modules/strip-literal": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
-      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3245,22 +2493,16 @@
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3276,8 +2518,6 @@
     },
     "node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3294,8 +2534,6 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3307,8 +2545,6 @@
     },
     "node_modules/tinypool": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3317,8 +2553,6 @@
     },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3327,8 +2561,6 @@
     },
     "node_modules/tinyspy": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
-      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3420,8 +2652,6 @@
     },
     "node_modules/vite": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.3.tgz",
-      "integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3495,8 +2725,6 @@
     },
     "node_modules/vite-node": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3518,8 +2746,6 @@
     },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3536,8 +2762,6 @@
     },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3549,8 +2773,6 @@
     },
     "node_modules/vitest": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3622,8 +2844,6 @@
     },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3649,8 +2869,6 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3771,133 +2989,163 @@
     },
     "packages/adapters/ollama": {
       "name": "@sisu-ai/adapter-ollama",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/adapters/openai": {
       "name": "@sisu-ai/adapter-openai",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/core": {
       "name": "@sisu-ai/core",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "zod": "^3.23.8"
+      }
+    },
+    "packages/middleware/context-compressor": {
+      "name": "@sisu-ai/mw-context-compressor",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/middleware/control-flow": {
       "name": "@sisu-ai/mw-control-flow",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/middleware/conversation-buffer": {
       "name": "@sisu-ai/mw-conversation-buffer",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/middleware/error-boundary": {
       "name": "@sisu-ai/mw-error-boundary",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/middleware/guardrails": {
       "name": "@sisu-ai/mw-guardrails",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/middleware/invariants": {
       "name": "@sisu-ai/mw-invariants",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/middleware/react-parser": {
       "name": "@sisu-ai/mw-react-parser",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/middleware/register-tools": {
       "name": "@sisu-ai/mw-register-tools",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/middleware/tool-calling": {
       "name": "@sisu-ai/mw-tool-calling",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/middleware/trace-viewer": {
       "name": "@sisu-ai/mw-trace-viewer",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/middleware/usage-tracker": {
       "name": "@sisu-ai/mw-usage-tracker",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
+      }
+    },
+    "packages/tools/github-projects": {
+      "extraneous": true
+    },
+    "packages/tools/summarize-text": {
+      "name": "@sisu-ai/tool-summarize-text",
+      "version": "1.0.0",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "peerDependencies": {
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/tools/web-fetch": {
       "name": "@sisu-ai/tool-web-fetch",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/tools/web-search-duckduckgo": {
       "name": "@sisu-ai/tool-web-search-duckduckgo",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
+      }
+    },
+    "packages/tools/web-search-google": {
+      "name": "@sisu-ai/tool-web-search-google",
+      "version": "1.0.0",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "peerDependencies": {
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/tools/web-search-openai": {
       "name": "@sisu-ai/tool-web-search-openai",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     },
     "packages/tools/wikipedia": {
       "name": "@sisu-ai/tool-wikipedia",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "0.2.1"
+        "@sisu-ai/core": "0.3.0"
       }
     }
   }

--- a/packages/adapters/openai/src/index.ts
+++ b/packages/adapters/openai/src/index.ts
@@ -31,7 +31,8 @@ export function openAIAdapter(opts: OpenAIAdapterOptions): LLM {
         messages: messages.map(m => toOpenAiMessage(m)),
         temperature: genOpts?.temperature ?? 0.2,
         ...(toolsParam.length ? { tools: toolsParam } : {}),
-        ...(tool_choice !== undefined ? { tool_choice } : {}),
+        // Some providers reject tool_choice when tools are not present; include only when tools exist
+        ...((toolsParam.length && tool_choice !== undefined) ? { tool_choice } : {}),
         ...(genOpts?.parallelToolCalls !== undefined ? { parallel_tool_calls: Boolean(genOpts.parallelToolCalls) } : {}),
       };
       const url = `${baseUrl}/v1/chat/completions`;

--- a/packages/tools/web-fetch/README.md
+++ b/packages/tools/web-fetch/README.md
@@ -16,9 +16,6 @@ Tool
 - Name: `webFetch`
 - Args: `{ url: string; format?: 'text'|'html'|'json'; maxBytes?: number }`
 - Returns: `{ url, finalUrl?, status, contentType?, title?, text?, html?, json? }`
-- Name: `webFetch`
-- Args: `{ url: string; format?: 'text'|'html'|'json'; maxBytes?: number }`
-- Returns: `{ url, finalUrl?, status, contentType?, title?, text?, html?, json? }`
 
 Behavior
 - Respects robots.txt by default for the provided User-Agent.

--- a/packages/tools/web-fetch/README.md
+++ b/packages/tools/web-fetch/README.md
@@ -20,13 +20,11 @@ Tool
 Behavior
 - Respects robots.txt by default for the provided User-Agent.
 - Follows redirects and reads up to `maxBytes` to avoid huge pages.
-- Follows redirects and reads up to `maxBytes` to avoid huge pages.
 - If `format: 'text'` (default) and page is HTML, strips tags (removes script/style) and decodes basic entities; includes `title`.
 - If `format: 'html'`, returns raw HTML and `title`.
 - If server returns JSON or `format: 'json'`, parses into `json`.
 - Non-OK responses return status and a short text body snippet for debugging.
 
 Notes
-- This is a minimal fetcher to empower summarization / extraction workflows. For deeper crawling, add queueing and URL normalization in upstream middleware.
 - This is a minimal fetcher to empower summarization / extraction workflows. For deeper crawling, add queueing, URL normalization, and robots.txt handling in upstream middleware.
 

--- a/packages/tools/web-fetch/README.md
+++ b/packages/tools/web-fetch/README.md
@@ -11,8 +11,6 @@ Environment / Flags
 - `WEB_FETCH_USER_AGENT` or `HTTP_USER_AGENT` (flag: `--web-fetch-user-agent`)
 - `WEB_FETCH_MAX_BYTES` (flag: `--web-fetch-max-bytes`) — default 500kB
 - `WEB_FETCH_RESPECT_ROBOTS` (flag: `--web-fetch-respect-robots`) — `1`/`true` (default) to honor robots.txt; set `0`/`false` to disable
-- `WEB_FETCH_USER_AGENT` or `HTTP_USER_AGENT` (flag: `--web-fetch-user-agent`)
-- `WEB_FETCH_MAX_BYTES` (flag: `--web-fetch-max-bytes`) — default 500kB
 
 Tool
 - Name: `webFetch`

--- a/packages/tools/web-fetch/README.md
+++ b/packages/tools/web-fetch/README.md
@@ -10,13 +10,21 @@ npm i @sisu-ai/tool-web-fetch
 Environment / Flags
 - `WEB_FETCH_USER_AGENT` or `HTTP_USER_AGENT` (flag: `--web-fetch-user-agent`)
 - `WEB_FETCH_MAX_BYTES` (flag: `--web-fetch-max-bytes`) — default 500kB
+- `WEB_FETCH_RESPECT_ROBOTS` (flag: `--web-fetch-respect-robots`) — `1`/`true` (default) to honor robots.txt; set `0`/`false` to disable
+- `WEB_FETCH_USER_AGENT` or `HTTP_USER_AGENT` (flag: `--web-fetch-user-agent`)
+- `WEB_FETCH_MAX_BYTES` (flag: `--web-fetch-max-bytes`) — default 500kB
 
 Tool
 - Name: `webFetch`
 - Args: `{ url: string; format?: 'text'|'html'|'json'; maxBytes?: number }`
 - Returns: `{ url, finalUrl?, status, contentType?, title?, text?, html?, json? }`
+- Name: `webFetch`
+- Args: `{ url: string; format?: 'text'|'html'|'json'; maxBytes?: number }`
+- Returns: `{ url, finalUrl?, status, contentType?, title?, text?, html?, json? }`
 
 Behavior
+- Respects robots.txt by default for the provided User-Agent.
+- Follows redirects and reads up to `maxBytes` to avoid huge pages.
 - Follows redirects and reads up to `maxBytes` to avoid huge pages.
 - If `format: 'text'` (default) and page is HTML, strips tags (removes script/style) and decodes basic entities; includes `title`.
 - If `format: 'html'`, returns raw HTML and `title`.
@@ -24,5 +32,6 @@ Behavior
 - Non-OK responses return status and a short text body snippet for debugging.
 
 Notes
+- This is a minimal fetcher to empower summarization / extraction workflows. For deeper crawling, add queueing and URL normalization in upstream middleware.
 - This is a minimal fetcher to empower summarization / extraction workflows. For deeper crawling, add queueing, URL normalization, and robots.txt handling in upstream middleware.
 

--- a/packages/tools/web-fetch/src/index.ts
+++ b/packages/tools/web-fetch/src/index.ts
@@ -8,6 +8,7 @@ export interface WebFetchArgs {
   url: string;
   format?: WebFetchFormat; // default 'text'
   maxBytes?: number; // safety cap for response size
+  respectRobots?: boolean; // default true (can be disabled via flag)
 }
 
 export interface WebFetchResult {
@@ -19,6 +20,9 @@ export interface WebFetchResult {
   text?: string;
   html?: string;
   json?: unknown;
+  // robots.txt metadata when blocked
+  robotsBlocked?: boolean;
+  robotsAgent?: string;
 }
 
 export const webFetch: Tool<WebFetchArgs> = {
@@ -29,11 +33,41 @@ export const webFetch: Tool<WebFetchArgs> = {
     format: z.enum(['text','html','json']).optional(),
     maxBytes: z.number().int().positive().max(5_000_000).optional(),
   }),
-  handler: async ({ url, format = 'text', maxBytes }, _ctx): Promise<WebFetchResult> => {
+  handler: async ({ url, format = 'text', maxBytes, respectRobots }, ctx): Promise<WebFetchResult> => {
     const ua = firstConfigValue(['WEB_FETCH_USER_AGENT','HTTP_USER_AGENT'])
       || 'SisuWebFetch/0.1 (+https://github.com/finger-gun/sisu)';
     const capEnv = firstConfigValue(['WEB_FETCH_MAX_BYTES']);
     const cap = Number(maxBytes ?? (capEnv !== undefined ? Number(capEnv) : 500_000));
+
+    // robots.txt compliance (default on; disable with arg or env WEB_FETCH_RESPECT_ROBOTS=0)
+    const respect = (() => {
+      if (typeof respectRobots === 'boolean') return respectRobots;
+      const env = firstConfigValue(['WEB_FETCH_RESPECT_ROBOTS','RESPECT_ROBOTS']);
+      if (env === undefined) return true; // default on
+      return !(env === '0' || /^false$/i.test(env));
+    })();
+
+    if (respect) {
+      const decision = await robotsDecision(url, ua).catch(() => ({ allowed: true } as RobotsDecision));
+      if (!decision.allowed) {
+        ctx?.log?.info?.('[webFetch] blocked by robots.txt', {
+          url,
+          userAgent: ua,
+          matchedAgent: decision.matchedAgent,
+          ruleType: decision.ruleType,
+          rulePattern: decision.rulePattern,
+        });
+        return {
+          url,
+          status: 403,
+          contentType: 'text/plain',
+          text: `Blocked by robots.txt (agent: ${decision.matchedAgent ?? 'unknown'}, rule: ${decision.ruleType ?? 'disallow'} ${decision.rulePattern ?? ''})`.
+            trim(),
+          robotsBlocked: true,
+          robotsAgent: ua
+        };
+      }
+    }
 
     const res = await fetch(url, {
       redirect: 'follow',
@@ -76,6 +110,115 @@ export const webFetch: Tool<WebFetchArgs> = {
 };
 
 export default webFetch;
+
+// --- robots.txt helpers ---
+type RobotsGroup = { agents: string[]; allows: string[]; disallows: string[] };
+type RobotsRules = { groups: RobotsGroup[] };
+type RobotsDecision = { allowed: boolean; matchedAgent?: string; ruleType?: 'allow'|'disallow'; rulePattern?: string };
+const robotsCache = new Map<string, { ts: number; rules: RobotsRules | null }>();
+
+async function robotsDecision(targetUrl: string, userAgent: string): Promise<RobotsDecision> {
+  const u = new URL(targetUrl);
+  const origin = `${u.protocol}//${u.host}`;
+  const cache = robotsCache.get(origin);
+  const now = Date.now();
+  if (!cache || (now - cache.ts) > 60 * 60 * 1000) { // 1h TTL
+    const robotsUrl = `${origin}/robots.txt`;
+    try {
+      const res = await fetch(robotsUrl, { headers: { 'User-Agent': userAgent, 'Accept': 'text/plain' } } as any);
+      const txt = await res.text();
+      const rules = res.ok ? parseRobots(txt) : null;
+      robotsCache.set(origin, { ts: now, rules });
+    } catch {
+      robotsCache.set(origin, { ts: now, rules: null });
+    }
+  }
+  const rules = robotsCache.get(origin)?.rules;
+  if (!rules) return { allowed: true };
+  return evaluateRobotsDetailed(rules, userAgent, u.pathname + (u.search || ''));
+}
+
+function parseRobots(text: string): RobotsRules {
+  const lines = text.split(/\r?\n/);
+  const groups: RobotsGroup[] = [];
+  let current: RobotsGroup | null = null;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const m = line.match(/^(user-agent|allow|disallow)\s*:\s*(.*)$/i);
+    if (!m) continue;
+    const key = m[1].toLowerCase();
+    const val = m[2].trim();
+    if (key === 'user-agent') {
+      // Start a new group if we already had one and it contains rules
+      if (!current || (current.allows.length + current.disallows.length) > 0) {
+        current = { agents: [], allows: [], disallows: [] };
+        groups.push(current);
+      }
+      current.agents.push(val.toLowerCase());
+    } else if (key === 'allow') {
+      if (!current) { current = { agents: ['*'], allows: [], disallows: [] }; groups.push(current); }
+      current.allows.push(val);
+    } else if (key === 'disallow') {
+      if (!current) { current = { agents: ['*'], allows: [], disallows: [] }; groups.push(current); }
+      current.disallows.push(val);
+    }
+  }
+  return { groups };
+}
+
+function evaluateRobotsDetailed(rules: RobotsRules, userAgent: string, pathWithQuery: string): RobotsDecision {
+  // Match exact agent token (product) ignoring case, or '*'.
+  // Example: 'SisuWebFetch/0.1 (+...)' -> baseAgent 'sisuwebfetch'
+  const baseAgent = (userAgent.split(/[\/\s]/)[0] || '').toLowerCase();
+  const agentMatches = (agent: string) => {
+    if (agent === '*') return true;
+    return agent.toLowerCase() === baseAgent;
+  };
+  const matching = rules.groups
+    .map(g => ({ g, matchedAgent: g.agents.find(agentMatches) }))
+    .filter(x => !!x.matchedAgent) as Array<{ g: RobotsGroup, matchedAgent: string }>;
+  const selected = matching.length
+    ? matching
+    : rules.groups.filter(g => g.agents.includes('*')).map(g => ({ g, matchedAgent: '*' }));
+  if (!selected.length) return { allowed: true };
+  // longest match wins between allow and disallow
+  let bestType: 'allow' | 'disallow' | undefined;
+  let bestLen = -1;
+  let bestPat: string | undefined;
+  let bestAgent: string | undefined;
+  for (const { g, matchedAgent } of selected) {
+    for (const pat of g.allows) {
+      if (!pat) continue;
+      if (patternMatches(pat, pathWithQuery)) {
+        const L = pat.length;
+        if (L > bestLen) { bestLen = L; bestType = 'allow'; bestPat = pat; bestAgent = matchedAgent; }
+      }
+    }
+    for (const pat of g.disallows) {
+      if (!pat) continue;
+      if (patternMatches(pat, pathWithQuery)) {
+        const L = pat.length;
+        if (L > bestLen) { bestLen = L; bestType = 'disallow'; bestPat = pat; bestAgent = matchedAgent; }
+      }
+    }
+  }
+  if (bestType === 'disallow') return { allowed: false, matchedAgent: bestAgent, ruleType: 'disallow', rulePattern: bestPat };
+  return { allowed: true, matchedAgent: bestAgent, ruleType: bestType, rulePattern: bestPat };
+}
+
+function patternMatches(pat: string, path: string): boolean {
+  // Support '*' wildcard and '$' end anchor; treat path as starting with '/'
+  let p = pat.trim();
+  if (p === '') return false;
+  // Empty disallow means allow all; already handled by return false above
+  // Convert to regex
+  const escaped = p.replace(/[.+?^${}()|\[\]\\]/g, r => '\\' + r);
+  let reStr = '^' + escaped.replace(/\*/g, '.*');
+  if (reStr.endsWith('\$')) { reStr = reStr.slice(0, -2) + '$'; }
+  const re = new RegExp(reStr);
+  return re.test(path);
+}
 
 async function readWithCap(res: Response, cap: number): Promise<Buffer> {
   // If body is not a stream (older fetch mocks), try res.text()

--- a/packages/tools/web-fetch/src/index.ts
+++ b/packages/tools/web-fetch/src/index.ts
@@ -32,6 +32,7 @@ export const webFetch: Tool<WebFetchArgs> = {
     url: z.string().url(),
     format: z.enum(['text','html','json']).optional(),
     maxBytes: z.number().int().positive().max(5_000_000).optional(),
+    respectRobots: z.boolean().optional(),
   }),
   handler: async ({ url, format = 'text', maxBytes, respectRobots }, ctx): Promise<WebFetchResult> => {
     const ua = firstConfigValue(['WEB_FETCH_USER_AGENT','HTTP_USER_AGENT'])

--- a/packages/tools/web-fetch/test/web-fetch.test.ts
+++ b/packages/tools/web-fetch/test/web-fetch.test.ts
@@ -63,3 +63,80 @@ test('htmlToText strips scripts/styles with sloppy closing tags and comments', a
   expect(res.text).not.toMatch(/alert\(1\)/);
   expect(res.text).toContain('Hello');
 });
+
+test('webFetch is blocked by robots.txt for disallowed paths', async () => {
+  // robots.txt disallows /secret on domain-a
+  vi.spyOn(globalThis, 'fetch' as any).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    headers: { get: () => 'text/plain' },
+    text: async () => 'User-agent: *\nDisallow: /secret',
+    url: 'https://domain-a.test/robots.txt',
+  } as any);
+
+  const res: any = await webFetch.handler({ url: 'https://domain-a.test/secret' } as any, {} as any);
+  expect(res.status).toBe(403);
+  expect(res.robotsBlocked).toBe(true);
+  expect(res.text).toMatch(/Blocked by robots.txt/);
+});
+
+test('webFetch bypasses robots.txt when respectRobots=false', async () => {
+  // Even if robots.txt would disallow, respectRobots=false should cause fetch to proceed
+  vi.spyOn(globalThis, 'fetch' as any).mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: { get: () => 'text/html' },
+    text: async () => '<title>Bypass</title><p>ok</p>',
+    url: 'https://domain-b.test/ok',
+  } as any);
+
+  const res: any = await webFetch.handler({ url: 'https://domain-b.test/ok', respectRobots: false } as any, {} as any);
+  expect(res.status).toBe(200);
+  expect(res.title).toBe('Bypass');
+  expect(res.text).toContain('ok');
+});
+
+test('webFetch reads streaming body and respects maxBytes cap', async () => {
+  // Mock a streaming body with two chunks of 50 bytes each
+  const chunks = [Buffer.from('a'.repeat(50)), Buffer.from('b'.repeat(50))];
+  let idx = 0;
+  const reader = {
+    read: async () => {
+      if (idx < chunks.length) {
+        const v = chunks[idx++];
+        return { done: false, value: new Uint8Array(v) };
+      }
+      return { done: true, value: undefined };
+    }
+  };
+  const body = { getReader: () => reader };
+
+  vi.spyOn(globalThis, 'fetch' as any).mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: { get: () => 'text/plain' },
+    body,
+    url: 'https://stream.test/large',
+  } as any);
+
+  const res: any = await webFetch.handler({ url: 'https://stream.test/large', maxBytes: 200 } as any, {} as any);
+  // with a large cap the full stream should be read (50+50)
+  expect(res.text.length).toBe(100);
+  expect(res.status).toBe(200);
+});
+
+test('webFetch falls back to text when JSON parse fails', async () => {
+  vi.spyOn(globalThis, 'fetch' as any).mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: { get: () => 'application/json' },
+    body: undefined,
+    text: async () => 'not a json',
+    url: 'https://json.test/bad'
+  } as any);
+
+  const res: any = await webFetch.handler({ url: 'https://json.test/bad' } as any, {} as any);
+  expect(res.json).toBeUndefined();
+  expect(res.text).toContain('not a json');
+  expect(res.status).toBe(200);
+});


### PR DESCRIPTION
This pull request introduces robust robots.txt compliance to the `webFetch` tool, ensuring that web requests respect site crawling policies by default. It also adds configurability for this behavior, exposes new metadata in results, and updates documentation accordingly.

**Robots.txt compliance and configurability:**
- The `webFetch` tool now checks robots.txt and blocks requests that are disallowed for the configured User-Agent by default. This can be disabled via the new `respectRobots` argument or the `WEB_FETCH_RESPECT_ROBOTS` environment variable. Blocked requests return a 403 status and include metadata about the block. [[1]](diffhunk://#diff-80b4603c5fb2d9be773596dae91800c2dc31a3a9cec49481f4451016e86b253dR11) [[2]](diffhunk://#diff-80b4603c5fb2d9be773596dae91800c2dc31a3a9cec49481f4451016e86b253dR23-R25) [[3]](diffhunk://#diff-80b4603c5fb2d9be773596dae91800c2dc31a3a9cec49481f4451016e86b253dL32-R71) [[4]](diffhunk://#diff-80b4603c5fb2d9be773596dae91800c2dc31a3a9cec49481f4451016e86b253dR114-R222)

**Documentation updates:**
- The `README.md` for `web-fetch` has been updated to document the new robots.txt compliance (on by default), the environment flag for disabling it, and the new result fields.

**Minor bugfix for LLM adapters:**
- The OpenAI adapter now only sends the `tool_choice` parameter if tools are present, preventing errors with some providers.