### PR TITLE
feat(ollama): add support for vision content and image handling

### DIFF
--- a/.changeset/fluffy-bananas-repair.md
+++ b/.changeset/fluffy-bananas-repair.md
@@ -1,0 +1,5 @@
+---
+"@sisu-ai/adapter-ollama": minor
+---
+
+Normalized Ollama image handling

--- a/.changeset/fluffy-bananas-repair.md
+++ b/.changeset/fluffy-bananas-repair.md
@@ -1,5 +1,0 @@
----
-"@sisu-ai/adapter-ollama": minor
----
-
-Normalized Ollama image handling

--- a/.changeset/fresh-wasps-train.md
+++ b/.changeset/fresh-wasps-train.md
@@ -1,5 +1,0 @@
----
-"@sisu-ai/adapter-openai": minor
----
-
-Minor fixes

--- a/.changeset/fresh-wasps-train.md
+++ b/.changeset/fresh-wasps-train.md
@@ -1,0 +1,5 @@
+---
+"@sisu-ai/adapter-openai": minor
+---
+
+Minor fixes

--- a/.changeset/ollama-images.md
+++ b/.changeset/ollama-images.md
@@ -1,0 +1,5 @@
+---
+"@sisu-ai/adapter-ollama": patch
+---
+
+Add image content support matching OpenAI's `image_url` format.

--- a/.changeset/ollama-images.md
+++ b/.changeset/ollama-images.md
@@ -1,5 +1,0 @@
----
-"@sisu-ai/adapter-ollama": patch
----
-
-Add image content support matching OpenAI's `image_url` format.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,17 @@ flowchart TD
   - `npm run ex:ollama:hello`
   - Open `examples/ollama-hello/traces/trace.html`
 
+- OpenAI vision:
+  - `cp examples/openai-vision/.env.example examples/openai-vision/.env`
+  - `npm run ex:openai:vision`
+  - Open `examples/openai-vision/traces/trace.html`
+
+- Ollama vision (local):
+  - `ollama serve && ollama pull llava:latest` (or another vision-capable model)
+  - `npm run ex:ollama:vision`
+  - Open `examples/ollama-vision/traces/trace.html`
+  - The Ollama adapter auto-fetches http(s) image URLs and inlines them as base64.
+
 
 ## Find your inner strength
 - [packages/core](packages/core/README.md)

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ flowchart TD
   - `npm run ex:ollama:hello`
   - Open `examples/ollama-hello/traces/trace.html`
 
+
 ## Find your inner strength
 - [packages/core](packages/core/README.md)
 - Adapters: [Anthropic](packages/adapters/anthropic/README.md), [Ollama](packages/adapters/ollama/README.md), [OpenAI](packages/adapters/openai/README.md)
@@ -277,9 +278,9 @@ Adapters are small shims that let Sisu talk to different LLM providers in a **no
 Every adapter implements the same `LLM.generate(messages, opts)` contract so you can swap providers without changing your agent code.
 
 | Adapter       | Package                      | Features                                                                               | Notes                                                                                                                         |
-| ------------- | ---------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| **OpenAI**    | `@sisu-ai/adapter-openai`    | ✅ Tool calling, ✅ JSON mode, ✅ Streaming, ✅ Vision (multi-part input), usage reporting | Works with OpenAI API and *any service that is OpenAI-compatible* (e.g. **LM Studio**, **vLLM**, some **OpenRouter** models). |
-| **Ollama**    | `@sisu-ai/adapter-ollama`    | ✅ Local inference, ✅ Tool calling, partial streaming                                   | Run local models via [`ollama serve`](https://ollama.com).                                                                    |
+|---------------|------------------------------|----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| **OpenAI**    | `@sisu-ai/adapter-openai`    | ✅ Tool calling, ✅ JSON mode, ✅ Streaming, ✅ Vision (multi-part input), ✅ Usage reporting | Works with OpenAI API and *any service that is OpenAI-compatible* (e.g. **LM Studio**, **vLLM**, some **OpenRouter** models). |
+| **Ollama**    | `@sisu-ai/adapter-ollama`    | ✅ Local inference, ✅ Tool calling, ✅ Streaming, ✅ Vision (multi-part input)                                   | Run local models via [`ollama serve`](https://ollama.com).                                                                    |
 | **Anthropic** | `@sisu-ai/adapter-anthropic` | ✅ Tool calling, ✅ Streaming, ✅ Usage reporting                                         | Claude family models. Slightly different tool-call semantics are normalized for you.                                          |
 
 ### When to re-use vs. add a new adapter
@@ -308,12 +309,12 @@ const model = openAIAdapter({ model: 'gpt-4o-mini' });
 // ctx.model = model
 ```
 
-| Feature       | Details                                                                                                                                                                 |
-|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Env Vars**  | - `OPENAI_API_KEY` or `API_KEY`<br>- `OPENAI_BASE_URL` or `BASE_URL`                                        |
-| **Tools**     | ✅ |
-| **Images**    | - Multi-part arrays: `{ type: 'text' \| 'image_url' }`<br>- Example: `[{ type: 'text', ...}, { type: 'image_url', ...}]`<br>- See `examples/openai-vision`              |
-| **Streaming** | ✅                                                                                                                                                                       |
+| Feature       | Details                                                                                                                                                    |
+|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Env Vars**  | - `OPENAI_API_KEY` or `API_KEY`<br>- `OPENAI_BASE_URL` or `BASE_URL`                                                                                       |
+| **Tools**     | ✅                                                                                                                                                          |
+| **Images**    | - Multi-part arrays: `{ type: 'text' \| 'image_url' }`<br>- Example: `[{ type: 'text', ...}, { type: 'image_url', ...}]`<br>- See `examples/openai-vision` |
+| **Streaming** | ✅                                                                                                                                                          |
 
 ---
 
@@ -325,12 +326,12 @@ const model = ollamaAdapter({ model: 'llama3.1' });
 // ctx.model = model
 ```
 
-| Feature       | Details                                                                                                 |
-|---------------|---------------------------------------------------------------------------------------------------------|
-| **Env Vars**  | - `OLLAMA_BASE_URL` or `BASE_URL` (default `http://localhost:11434`)                                    |
-| **Tools**     | ✅ |
-| **Images**    | –                                                                                                       |
-| **Streaming** | ✅                                                                                                       |
+| Feature       | Details                                                              |
+|---------------|----------------------------------------------------------------------|
+| **Env Vars**  | - `OLLAMA_BASE_URL` or `BASE_URL` (default `http://localhost:11434`) |
+| **Tools**     | ✅                                                                    |
+| **Images**    | - Multi-part arrays: `{ type: 'text' \| 'image_url' }`<br>- Example: `[{ type: 'text', ...}, { type: 'image_url', ...}]`<br>- See `examples/ollama-vision` |
+| **Streaming** | ✅                                                                    |
 
 ---
 
@@ -342,12 +343,12 @@ const model = anthropicAdapter({ model: 'claude-sonnet-4-20250514' });
 // ctx.model = model
 ```
 
-| Feature       | Details                                                                                                                                          |
-|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Env Vars**  | - `ANTHROPIC_API_KEY` or `API_KEY`<br>- `ANTHROPIC_BASE_URL` or `BASE_URL`                                                           |
-| **Tools**     | ✅ |
-| **Images**    | –                                                                                                                                                |
-| **Streaming** | ✅                                                                                                                                                |
+| Feature       | Details                                                                    |
+|---------------|----------------------------------------------------------------------------|
+| **Env Vars**  | - `ANTHROPIC_API_KEY` or `API_KEY`<br>- `ANTHROPIC_BASE_URL` or `BASE_URL` |
+| **Tools**     | ✅                                                                          |
+| **Images**    | –                                                                          |
+| **Streaming** | ✅                                                                          |
 
 ---
 

--- a/examples/ollama-hello/CHANGELOG.md
+++ b/examples/ollama-hello/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ollama-hello
 
+## 0.1.15
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-ollama@4.1.0
+
 ## 0.1.14
 
 ### Patch Changes

--- a/examples/ollama-hello/CHANGELOG.md
+++ b/examples/ollama-hello/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ollama-hello
 
+## 0.1.14
+
+### Patch Changes
+
+- Updated dependencies [43e3b32]
+  - @sisu-ai/adapter-ollama@4.0.3
+
 ## 0.1.13
 
 ### Patch Changes

--- a/examples/ollama-hello/package.json
+++ b/examples/ollama-hello/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-hello",
   "private": true,
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-ollama": "4.0.2",
+    "@sisu-ai/adapter-ollama": "4.0.3",
     "@sisu-ai/mw-usage-tracker": "4.0.2",
     "@sisu-ai/mw-trace-viewer": "5.0.2",
     "dotenv": "^16.4.5"

--- a/examples/ollama-hello/package.json
+++ b/examples/ollama-hello/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-hello",
   "private": true,
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-ollama": "4.0.3",
+    "@sisu-ai/adapter-ollama": "4.1.0",
     "@sisu-ai/mw-usage-tracker": "4.0.2",
     "@sisu-ai/mw-trace-viewer": "5.0.2",
     "dotenv": "^16.4.5"

--- a/examples/ollama-stream/CHANGELOG.md
+++ b/examples/ollama-stream/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ollama-stream
 
+## 0.1.9
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-ollama@4.1.0
+
 ## 0.1.8
 
 ### Patch Changes

--- a/examples/ollama-stream/CHANGELOG.md
+++ b/examples/ollama-stream/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ollama-stream
 
+## 0.1.8
+
+### Patch Changes
+
+- Updated dependencies [43e3b32]
+  - @sisu-ai/adapter-ollama@4.0.3
+
 ## 0.1.7
 
 ### Patch Changes

--- a/examples/ollama-stream/package.json
+++ b/examples/ollama-stream/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-stream",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-ollama": "4.0.3",
+    "@sisu-ai/adapter-ollama": "4.1.0",
     "dotenv": "^16.4.5"
   }
 }

--- a/examples/ollama-stream/package.json
+++ b/examples/ollama-stream/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-stream",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-ollama": "4.0.2",
+    "@sisu-ai/adapter-ollama": "4.0.3",
     "dotenv": "^16.4.5"
   }
 }

--- a/examples/ollama-vision/CHANGELOG.md
+++ b/examples/ollama-vision/CHANGELOG.md
@@ -1,0 +1,8 @@
+# ollama-vision
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [43e3b32]
+  - @sisu-ai/adapter-ollama@4.0.3

--- a/examples/ollama-vision/CHANGELOG.md
+++ b/examples/ollama-vision/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ollama-vision
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-ollama@4.1.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/examples/ollama-vision/README.md
+++ b/examples/ollama-vision/README.md
@@ -1,0 +1,19 @@
+# Ollama Vision Example
+
+Demonstrates image inputs using Ollama multi-part content (text + image_url). The example fetches the image URL and converts it to base64, which Ollama expects in the `images` field under the hood.
+
+Usage
+- Quick start: `npm run ex:ollama:vision`
+- Alternate (full command): `TRACE_HTML=1 npm run dev -w examples/ollama-vision -- --trace --trace-style=dark`
+
+Notes
+- Requires a vision-capable Ollama model (e.g. `llava:latest` or a Qwen VL model). Make sure it’s pulled locally: `ollama pull llava:latest`.
+- You can pass your own image URL as the first CLI arg. The example will download it and inline as base64 automatically.
+
+Config Flags (CLI overrides env)
+- `--ollama-base-url`, `--base-url`
+- Tracing: `--trace` and `--trace-style=light|dark`
+
+Env Vars (alternatives)
+- `OLLAMA_BASE_URL` or `BASE_URL`
+- Tracing: `TRACE_JSON=1`, `TRACE_HTML=1`, `TRACE_STYLE=...`

--- a/examples/ollama-vision/README.md
+++ b/examples/ollama-vision/README.md
@@ -1,6 +1,6 @@
 # Ollama Vision Example
 
-Demonstrates image inputs using Ollama multi-part content (text + image_url). The example fetches the image URL and converts it to base64, which Ollama expects in the `images` field under the hood.
+Demonstrates image inputs using Ollama multi-part content (text + image_url). The adapter fetches http(s) image URLs and inlines them as base64 automatically under the hood.
 
 Usage
 - Quick start: `npm run ex:ollama:vision`
@@ -8,7 +8,7 @@ Usage
 
 Notes
 - Requires a vision-capable Ollama model (e.g. `llava:latest` or a Qwen VL model). Make sure it’s pulled locally: `ollama pull llava:latest`.
-- You can pass your own image URL as the first CLI arg. The example will download it and inline as base64 automatically.
+- You can pass your own image URL as the first CLI arg. The adapter will download it and inline as base64 automatically.
 
 Config Flags (CLI overrides env)
 - `--ollama-base-url`, `--base-url`

--- a/examples/ollama-vision/package.json
+++ b/examples/ollama-vision/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-vision",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-ollama": "4.0.3",
+    "@sisu-ai/adapter-ollama": "4.1.0",
     "@sisu-ai/mw-usage-tracker": "4.0.2",
     "@sisu-ai/mw-trace-viewer": "5.0.2",
     "dotenv": "^16.4.5"

--- a/examples/ollama-vision/package.json
+++ b/examples/ollama-vision/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ollama-vision",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@sisu-ai/core": "1.1.2",
+    "@sisu-ai/adapter-ollama": "4.0.2",
+    "@sisu-ai/mw-usage-tracker": "4.0.2",
+    "@sisu-ai/mw-trace-viewer": "5.0.2",
+    "dotenv": "^16.4.5"
+  }
+}
+

--- a/examples/ollama-vision/package.json
+++ b/examples/ollama-vision/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-vision",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,10 +9,9 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-ollama": "4.0.2",
+    "@sisu-ai/adapter-ollama": "4.0.3",
     "@sisu-ai/mw-usage-tracker": "4.0.2",
     "@sisu-ai/mw-trace-viewer": "5.0.2",
     "dotenv": "^16.4.5"
   }
 }
-

--- a/examples/ollama-vision/src/index.ts
+++ b/examples/ollama-vision/src/index.ts
@@ -9,29 +9,14 @@ import { ollamaAdapter } from '@sisu-ai/adapter-ollama';
 const model = ollamaAdapter({ model: process.env.MODEL || 'llava:latest' });
 
 // Example image (public domain) or first CLI arg
-const imageSrc = process.argv.find(a => a.startsWith('http'))
-  || 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg';
+const imageUrl = 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg';
 
-async function toBase64(src: string): Promise<string> {
-  // If already looks like base64 (data URL), strip prefix and return the payload
-  if (src.startsWith('data:')) return src.split(',')[1] ?? '';
-  // Simple heuristic: if not http(s), return as-is
-  if (!/^https?:\/\//i.test(src)) return src;
-  const res = await fetch(src);
-  if (!res.ok) throw new Error(`Failed to fetch image: ${res.status} ${res.statusText}`);
-  const buf = Buffer.from(await res.arrayBuffer());
-  return buf.toString('base64');
-}
-
-// Prepare base64 image for Ollama (expects images as base64 strings)
-const base64Image = await toBase64(imageSrc);
-
-// Use content parts to include text + image (adapter maps to images[])
+// Use content parts to include text + image (adapter maps to images[] and auto-fetches URL → base64)
 const userMessage: any = {
   role: 'user',
   content: [
     { type: 'text', text: 'Please describe this image.' },
-    { type: 'image_url', image_url: { url: base64Image } },
+    { type: 'image_url', image_url: { url: imageUrl } },
   ],
 };
 

--- a/examples/ollama-vision/src/index.ts
+++ b/examples/ollama-vision/src/index.ts
@@ -1,21 +1,37 @@
 import 'dotenv/config';
 import { Agent, createConsoleLogger, InMemoryKV, NullStream, type Ctx } from '@sisu-ai/core';
 import { usageTracker } from '@sisu-ai/mw-usage-tracker';
-import { openAIAdapter } from '@sisu-ai/adapter-openai';
 import { traceViewer } from '@sisu-ai/mw-trace-viewer';
+import { ollamaAdapter } from '@sisu-ai/adapter-ollama';
 
-// Vision-capable model
-const model = openAIAdapter({ model: process.env.MODEL || 'gpt-4o-mini' });
-// Example image (public domain)
-const imageUrl = process.argv.find(a => a.startsWith('http'))
+// Vision-capable model (ensure pulled locally)
+// Examples: `llava:latest`, `qwen2.5-vl:latest` (model availability may vary)
+const model = ollamaAdapter({ model: process.env.MODEL || 'llava:latest' });
+
+// Example image (public domain) or first CLI arg
+const imageSrc = process.argv.find(a => a.startsWith('http'))
   || 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg';
 
-// Use content parts to include text + image
+async function toBase64(src: string): Promise<string> {
+  // If already looks like base64 (data URL), strip prefix and return the payload
+  if (src.startsWith('data:')) return src.split(',')[1] ?? '';
+  // Simple heuristic: if not http(s), return as-is
+  if (!/^https?:\/\//i.test(src)) return src;
+  const res = await fetch(src);
+  if (!res.ok) throw new Error(`Failed to fetch image: ${res.status} ${res.statusText}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  return buf.toString('base64');
+}
+
+// Prepare base64 image for Ollama (expects images as base64 strings)
+const base64Image = await toBase64(imageSrc);
+
+// Use content parts to include text + image (adapter maps to images[])
 const userMessage: any = {
   role: 'user',
   content: [
     { type: 'text', text: 'Please describe this image.' },
-    { type: 'image_url', image_url: { url: imageUrl } },
+    { type: 'image_url', image_url: { url: base64Image } },
   ],
 };
 
@@ -26,7 +42,6 @@ const ctx: Ctx = {
     userMessage,
   ] as any,
   model,
-  // Minimal runtime plumbing
   tools: { list: () => [], get: () => undefined, register: () => { /* no-op */ } },
   memory: new InMemoryKV(),
   stream: new NullStream(),
@@ -43,9 +58,8 @@ const generateOnce = async (c: Ctx) => {
 const app = new Agent()
   .use(async (c, next) => { try { await next(); } catch (e) { c.log.error(e); c.messages.push({ role: 'assistant', content: 'Sorry, something went wrong.' }); } })
   .use(traceViewer())
-  .use(usageTracker({
-    '*': { inputPer1M: 0.15, outputPer1M: 0.60, imagePer1K: 0.217 },
-  }, { logPerCall: true }))
+  // Local models, so set costs to zero
+  .use(usageTracker({ '*': { inputPer1K: 0, outputPer1K: 0, imagePer1K: 0 } }, { logPerCall: true }))
   .use(generateOnce);
 
 await app.handler()(ctx);

--- a/examples/ollama-vision/tsconfig.json
+++ b/examples/ollama-vision/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}
+

--- a/examples/ollama-weather/CHANGELOG.md
+++ b/examples/ollama-weather/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ollama-weather
 
+## 0.1.14
+
+### Patch Changes
+
+- Updated dependencies [43e3b32]
+  - @sisu-ai/adapter-ollama@4.0.3
+
 ## 0.1.13
 
 ### Patch Changes

--- a/examples/ollama-weather/CHANGELOG.md
+++ b/examples/ollama-weather/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ollama-weather
 
+## 0.1.15
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-ollama@4.1.0
+
 ## 0.1.14
 
 ### Patch Changes

--- a/examples/ollama-weather/package.json
+++ b/examples/ollama-weather/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-weather",
   "private": true,
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-ollama": "4.0.2",
+    "@sisu-ai/adapter-ollama": "4.0.3",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",
     "@sisu-ai/mw-error-boundary": "4.0.2",

--- a/examples/ollama-weather/package.json
+++ b/examples/ollama-weather/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-weather",
   "private": true,
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-ollama": "4.0.3",
+    "@sisu-ai/adapter-ollama": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",
     "@sisu-ai/mw-error-boundary": "4.0.2",

--- a/examples/ollama-web-search/CHANGELOG.md
+++ b/examples/ollama-web-search/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ollama-web-search
 
+## 0.1.12
+
+### Patch Changes
+
+- Updated dependencies [43e3b32]
+  - @sisu-ai/adapter-ollama@4.0.3
+
 ## 0.1.11
 
 ### Patch Changes

--- a/examples/ollama-web-search/CHANGELOG.md
+++ b/examples/ollama-web-search/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ollama-web-search
 
+## 0.1.13
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-ollama@4.1.0
+
 ## 0.1.12
 
 ### Patch Changes

--- a/examples/ollama-web-search/package.json
+++ b/examples/ollama-web-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-web-search",
   "private": true,
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-ollama": "4.0.3",
+    "@sisu-ai/adapter-ollama": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-tool-calling": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",

--- a/examples/ollama-web-search/package.json
+++ b/examples/ollama-web-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ollama-web-search",
   "private": true,
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-ollama": "4.0.2",
+    "@sisu-ai/adapter-ollama": "4.0.3",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-tool-calling": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",

--- a/examples/openai-aws-s3/CHANGELOG.md
+++ b/examples/openai-aws-s3/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-aws-s3
 
+## 0.1.13
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.1.12
 
 ### Patch Changes

--- a/examples/openai-aws-s3/package.json
+++ b/examples/openai-aws-s3/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-aws-s3",
   "private": true,
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-tool-calling": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",

--- a/examples/openai-azure-blob/CHANGELOG.md
+++ b/examples/openai-azure-blob/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-azure-blob
 
+## 0.1.13
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.1.12
 
 ### Patch Changes

--- a/examples/openai-azure-blob/package.json
+++ b/examples/openai-azure-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-azure-blob",
   "private": true,
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-tool-calling": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",

--- a/examples/openai-branch/CHANGELOG.md
+++ b/examples/openai-branch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-branch
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/openai-branch/package.json
+++ b/examples/openai-branch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-branch",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-control-flow": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",
     "@sisu-ai/mw-error-boundary": "4.0.2",

--- a/examples/openai-control-flow/CHANGELOG.md
+++ b/examples/openai-control-flow/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-control-flow
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/openai-control-flow/package.json
+++ b/examples/openai-control-flow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-control-flow",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",
     "@sisu-ai/mw-error-boundary": "4.0.2",

--- a/examples/openai-extract-urls/CHANGELOG.md
+++ b/examples/openai-extract-urls/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-extract-urls
 
+## 0.1.13
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.1.12
 
 ### Patch Changes

--- a/examples/openai-extract-urls/package.json
+++ b/examples/openai-extract-urls/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-extract-urls",
   "private": true,
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-tool-calling": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",

--- a/examples/openai-github-projects/CHANGELOG.md
+++ b/examples/openai-github-projects/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-github-projects
 
+## 0.1.13
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.1.12
 
 ### Patch Changes

--- a/examples/openai-github-projects/package.json
+++ b/examples/openai-github-projects/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-github-projects",
   "private": true,
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-tool-calling": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",

--- a/examples/openai-graph/CHANGELOG.md
+++ b/examples/openai-graph/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-graph
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/openai-graph/package.json
+++ b/examples/openai-graph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-graph",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-control-flow": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",
     "@sisu-ai/mw-error-boundary": "4.0.2",

--- a/examples/openai-guardrails/CHANGELOG.md
+++ b/examples/openai-guardrails/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-guardrails
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/openai-guardrails/package.json
+++ b/examples/openai-guardrails/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-guardrails",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-guardrails": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",
     "@sisu-ai/mw-error-boundary": "4.0.2",

--- a/examples/openai-hello/CHANGELOG.md
+++ b/examples/openai-hello/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-hello
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/openai-hello/package.json
+++ b/examples/openai-hello/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-hello",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -11,7 +11,7 @@
     "@sisu-ai/core": "1.1.2",
     "@sisu-ai/mw-usage-tracker": "4.0.2",
     "@sisu-ai/mw-trace-viewer": "5.0.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "dotenv": "^16.4.5"
   }
 }

--- a/examples/openai-parallel/CHANGELOG.md
+++ b/examples/openai-parallel/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-parallel
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/openai-parallel/package.json
+++ b/examples/openai-parallel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-parallel",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-control-flow": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",
     "@sisu-ai/mw-error-boundary": "4.0.2",

--- a/examples/openai-rag-chroma/CHANGELOG.md
+++ b/examples/openai-rag-chroma/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sisu-ai/example-openai-rag-chroma
 
+## 0.1.13
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.1.12
 
 ### Patch Changes

--- a/examples/openai-rag-chroma/package.json
+++ b/examples/openai-rag-chroma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sisu-ai/example-openai-rag-chroma",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "private": true,
   "main": "dist/index.js",
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-trace-viewer": "5.0.2",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-rag": "3.0.2",

--- a/examples/openai-react/CHANGELOG.md
+++ b/examples/openai-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-react
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/openai-react/package.json
+++ b/examples/openai-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-react",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-react-parser": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",

--- a/examples/openai-server/CHANGELOG.md
+++ b/examples/openai-server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-server
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.0.7
 
 ### Patch Changes

--- a/examples/openai-server/package.json
+++ b/examples/openai-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-server",
   "private": true,
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-agent-run-api": "2.0.2",
     "@sisu-ai/server": "2.0.2",
     "dotenv": "^16.4.5"

--- a/examples/openai-stream/CHANGELOG.md
+++ b/examples/openai-stream/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-stream
 
+## 0.1.9
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.1.8
 
 ### Patch Changes

--- a/examples/openai-stream/package.json
+++ b/examples/openai-stream/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-stream",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "dotenv": "^16.4.5"
   }
 }

--- a/examples/openai-terminal/CHANGELOG.md
+++ b/examples/openai-terminal/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-terminal
 
+## 0.1.10
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.1.9
 
 ### Patch Changes

--- a/examples/openai-terminal/package.json
+++ b/examples/openai-terminal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-terminal",
   "private": true,
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -11,7 +11,7 @@
     "dotenv": "^16.4.5",
     "ts-node": "^10.9.2",
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",
     "@sisu-ai/mw-tool-calling": "4.0.2",

--- a/examples/openai-vision/CHANGELOG.md
+++ b/examples/openai-vision/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-vision
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/openai-vision/package.json
+++ b/examples/openai-vision/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-vision",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -11,7 +11,7 @@
     "@sisu-ai/core": "1.1.2",
     "@sisu-ai/mw-usage-tracker": "4.0.2",
     "@sisu-ai/mw-trace-viewer": "5.0.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "dotenv": "^16.4.5"
   }
 }

--- a/examples/openai-weather/CHANGELOG.md
+++ b/examples/openai-weather/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-weather
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/openai-weather/package.json
+++ b/examples/openai-weather/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-weather",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",
     "@sisu-ai/mw-error-boundary": "4.0.2",

--- a/examples/openai-web-fetch/CHANGELOG.md
+++ b/examples/openai-web-fetch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-web-fetch
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/openai-web-fetch/package.json
+++ b/examples/openai-web-fetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-web-fetch",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-tool-calling": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",

--- a/examples/openai-web-search/CHANGELOG.md
+++ b/examples/openai-web-search/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-web-search
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/openai-web-search/package.json
+++ b/examples/openai-web-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-web-search",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-tool-calling": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",

--- a/examples/openai-wikipedia/CHANGELOG.md
+++ b/examples/openai-wikipedia/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openai-wikipedia
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies [9b419d0]
+  - @sisu-ai/adapter-openai@4.1.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/openai-wikipedia/package.json
+++ b/examples/openai-wikipedia/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-wikipedia",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "ts-node src/index.ts",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@sisu-ai/core": "1.1.2",
-    "@sisu-ai/adapter-openai": "4.0.2",
+    "@sisu-ai/adapter-openai": "4.1.0",
     "@sisu-ai/mw-register-tools": "4.0.2",
     "@sisu-ai/mw-tool-calling": "4.0.2",
     "@sisu-ai/mw-conversation-buffer": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,18 +33,18 @@
       }
     },
     "examples/anthropic-control-flow": {
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
-        "@sisu-ai/adapter-anthropic": "2.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-control-flow": "4.0.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-invariants": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-anthropic": "2.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-control-flow": "4.0.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-invariants": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"
       }
@@ -67,12 +67,12 @@
       }
     },
     "examples/anthropic-hello": {
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
-        "@sisu-ai/adapter-anthropic": "2.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-anthropic": "2.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -87,10 +87,10 @@
       }
     },
     "examples/anthropic-stream": {
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
-        "@sisu-ai/adapter-anthropic": "2.0.1",
-        "@sisu-ai/core": "1.1.1",
+        "@sisu-ai/adapter-anthropic": "2.0.2",
+        "@sisu-ai/core": "1.1.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -105,19 +105,19 @@
       }
     },
     "examples/anthropic-weather": {
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
-        "@sisu-ai/adapter-anthropic": "2.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-control-flow": "4.0.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-invariants": "4.0.1",
-        "@sisu-ai/mw-react-parser": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-anthropic": "2.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-control-flow": "4.0.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-invariants": "4.0.2",
+        "@sisu-ai/mw-react-parser": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"
       }
@@ -140,12 +140,12 @@
       }
     },
     "examples/ollama-hello": {
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
-        "@sisu-ai/adapter-ollama": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-ollama": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -160,10 +160,10 @@
       }
     },
     "examples/ollama-stream": {
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
-        "@sisu-ai/adapter-ollama": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
+        "@sisu-ai/adapter-ollama": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -177,21 +177,41 @@
         "url": "https://dotenvx.com"
       }
     },
-    "examples/ollama-weather": {
-      "version": "0.1.12",
+    "examples/ollama-vision": {
+      "version": "0.1.0",
       "dependencies": {
-        "@sisu-ai/adapter-ollama": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-control-flow": "4.0.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-guardrails": "4.0.1",
-        "@sisu-ai/mw-invariants": "4.0.1",
-        "@sisu-ai/mw-react-parser": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-ollama": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
+        "dotenv": "^16.4.5"
+      }
+    },
+    "examples/ollama-vision/node_modules/dotenv": {
+      "version": "16.6.1",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "examples/ollama-weather": {
+      "version": "0.1.13",
+      "dependencies": {
+        "@sisu-ai/adapter-ollama": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-control-flow": "4.0.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-guardrails": "4.0.2",
+        "@sisu-ai/mw-invariants": "4.0.2",
+        "@sisu-ai/mw-react-parser": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"
       }
@@ -214,16 +234,16 @@
       }
     },
     "examples/ollama-web-search": {
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
-        "@sisu-ai/adapter-ollama": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/tool-web-search-duckduckgo": "3.0.1",
+        "@sisu-ai/adapter-ollama": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/tool-web-search-duckduckgo": "3.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -238,15 +258,15 @@
       }
     },
     "examples/openai-aws-s3": {
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
         "@sisu-ai/tool-aws-s3": "1.0.2",
         "dotenv": "^16.4.5"
       }
@@ -262,16 +282,16 @@
       }
     },
     "examples/openai-azure-blob": {
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/tool-azure-blob": "4.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/tool-azure-blob": "4.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -286,15 +306,15 @@
       }
     },
     "examples/openai-branch": {
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-control-flow": "4.0.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-control-flow": "4.0.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -309,18 +329,18 @@
       }
     },
     "examples/openai-control-flow": {
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-control-flow": "4.0.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-invariants": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-control-flow": "4.0.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-invariants": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"
       }
@@ -343,16 +363,16 @@
       }
     },
     "examples/openai-extract-urls": {
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/tool-extract-urls": "4.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/tool-extract-urls": "4.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -367,16 +387,16 @@
       }
     },
     "examples/openai-github-projects": {
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/tool-github-projects": "4.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/tool-github-projects": "4.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -391,15 +411,15 @@
       }
     },
     "examples/openai-graph": {
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-control-flow": "4.0.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-control-flow": "4.0.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -414,15 +434,15 @@
       }
     },
     "examples/openai-guardrails": {
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-guardrails": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-guardrails": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -437,12 +457,12 @@
       }
     },
     "examples/openai-hello": {
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -457,15 +477,15 @@
       }
     },
     "examples/openai-parallel": {
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-control-flow": "4.0.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-control-flow": "4.0.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -481,14 +501,14 @@
     },
     "examples/openai-rag-chroma": {
       "name": "@sisu-ai/example-openai-rag-chroma",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-rag": "3.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/tool-vec-chroma": "2.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-rag": "3.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/tool-vec-chroma": "2.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -503,16 +523,16 @@
       }
     },
     "examples/openai-react": {
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-react-parser": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-react-parser": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"
       }
@@ -535,12 +555,12 @@
       }
     },
     "examples/openai-server": {
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-agent-run-api": "2.0.1",
-        "@sisu-ai/server": "2.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-agent-run-api": "2.0.2",
+        "@sisu-ai/server": "2.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -555,10 +575,10 @@
       }
     },
     "examples/openai-stream": {
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -573,16 +593,16 @@
       }
     },
     "examples/openai-terminal": {
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/tool-terminal": "2.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/tool-terminal": "2.0.2",
         "dotenv": "^16.4.5",
         "ts-node": "^10.9.2"
       }
@@ -598,12 +618,12 @@
       }
     },
     "examples/openai-vision": {
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -618,18 +638,18 @@
       }
     },
     "examples/openai-weather": {
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-control-flow": "4.0.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-invariants": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/mw-usage-tracker": "4.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-control-flow": "4.0.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-invariants": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/mw-usage-tracker": "4.0.2",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"
       }
@@ -652,16 +672,16 @@
       }
     },
     "examples/openai-web-fetch": {
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/tool-web-fetch": "3.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/tool-web-fetch": "3.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -676,16 +696,16 @@
       }
     },
     "examples/openai-web-search": {
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/tool-web-search-openai": "3.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/tool-web-search-openai": "3.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -700,16 +720,16 @@
       }
     },
     "examples/openai-wikipedia": {
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
-        "@sisu-ai/adapter-openai": "4.0.1",
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/mw-conversation-buffer": "4.0.1",
-        "@sisu-ai/mw-error-boundary": "4.0.1",
-        "@sisu-ai/mw-register-tools": "4.0.1",
-        "@sisu-ai/mw-tool-calling": "4.0.1",
-        "@sisu-ai/mw-trace-viewer": "5.0.1",
-        "@sisu-ai/tool-wikipedia": "3.0.1",
+        "@sisu-ai/adapter-openai": "4.0.2",
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/mw-conversation-buffer": "4.0.2",
+        "@sisu-ai/mw-error-boundary": "4.0.2",
+        "@sisu-ai/mw-register-tools": "4.0.2",
+        "@sisu-ai/mw-tool-calling": "4.0.2",
+        "@sisu-ai/mw-trace-viewer": "5.0.2",
+        "@sisu-ai/tool-wikipedia": "3.0.2",
         "dotenv": "^16.4.5"
       }
     },
@@ -4998,6 +5018,10 @@
       "resolved": "examples/ollama-stream",
       "link": true
     },
+    "node_modules/ollama-vision": {
+      "resolved": "examples/ollama-vision",
+      "link": true
+    },
     "node_modules/ollama-weather": {
       "resolved": "examples/ollama-weather",
       "link": true
@@ -6280,153 +6304,153 @@
     },
     "packages/adapters/anthropic": {
       "name": "@sisu-ai/adapter-anthropic",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/adapters/ollama": {
       "name": "@sisu-ai/adapter-ollama",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/adapters/openai": {
       "name": "@sisu-ai/adapter-openai",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/core": {
       "name": "@sisu-ai/core",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0"
     },
     "packages/middleware/agent-run-api": {
       "name": "@sisu-ai/mw-agent-run-api",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1",
-        "@sisu-ai/server": "2.0.1"
+        "@sisu-ai/core": "1.1.2",
+        "@sisu-ai/server": "2.0.2"
       }
     },
     "packages/middleware/context-compressor": {
       "name": "@sisu-ai/mw-context-compressor",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/middleware/control-flow": {
       "name": "@sisu-ai/mw-control-flow",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/middleware/conversation-buffer": {
       "name": "@sisu-ai/mw-conversation-buffer",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/middleware/cors": {
       "name": "@sisu-ai/mw-cors",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/middleware/error-boundary": {
       "name": "@sisu-ai/mw-error-boundary",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/middleware/guardrails": {
       "name": "@sisu-ai/mw-guardrails",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/middleware/invariants": {
       "name": "@sisu-ai/mw-invariants",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/middleware/rag": {
       "name": "@sisu-ai/mw-rag",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1",
+        "@sisu-ai/core": "1.1.2",
         "@sisu-ai/vector-core": "1.0.4"
       }
     },
     "packages/middleware/react-parser": {
       "name": "@sisu-ai/mw-react-parser",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/middleware/register-tools": {
       "name": "@sisu-ai/mw-register-tools",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/middleware/tool-calling": {
       "name": "@sisu-ai/mw-tool-calling",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/middleware/trace-viewer": {
       "name": "@sisu-ai/mw-trace-viewer",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/middleware/usage-tracker": {
       "name": "@sisu-ai/mw-usage-tracker",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/server": {
       "name": "@sisu-ai/server",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/tools/aws-s3": {
@@ -6447,14 +6471,14 @@
     },
     "packages/tools/azure-blob": {
       "name": "@sisu-ai/tool-azure-blob",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/storage-blob": "^12.15.0",
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/tools/azure-blob/node_modules/zod": {
@@ -6466,13 +6490,13 @@
     },
     "packages/tools/extract-urls": {
       "name": "@sisu-ai/tool-extract-urls",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/tools/extract-urls/node_modules/zod": {
@@ -6484,13 +6508,13 @@
     },
     "packages/tools/github-projects": {
       "name": "@sisu-ai/tool-github-projects",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/tools/github-projects/node_modules/zod": {
@@ -6502,13 +6526,13 @@
     },
     "packages/tools/summarize-text": {
       "name": "@sisu-ai/tool-summarize-text",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/tools/summarize-text/node_modules/zod": {
@@ -6520,13 +6544,13 @@
     },
     "packages/tools/terminal": {
       "name": "@sisu-ai/tool-terminal",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
         "minimatch": "^9.0.3",
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/tools/terminal/node_modules/zod": {
@@ -6538,14 +6562,14 @@
     },
     "packages/tools/vec-chroma": {
       "name": "@sisu-ai/tool-vec-chroma",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chromadb": "^1.8.0",
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1",
+        "@sisu-ai/core": "1.1.2",
         "@sisu-ai/vector-core": "1.0.4"
       }
     },
@@ -6593,13 +6617,13 @@
     },
     "packages/tools/web-fetch": {
       "name": "@sisu-ai/tool-web-fetch",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/tools/web-fetch/node_modules/zod": {
@@ -6611,13 +6635,13 @@
     },
     "packages/tools/web-search-duckduckgo": {
       "name": "@sisu-ai/tool-web-search-duckduckgo",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/tools/web-search-duckduckgo/node_modules/zod": {
@@ -6629,13 +6653,13 @@
     },
     "packages/tools/web-search-openai": {
       "name": "@sisu-ai/tool-web-search-openai",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/tools/web-search-openai/node_modules/zod": {
@@ -6647,13 +6671,13 @@
     },
     "packages/tools/wikipedia": {
       "name": "@sisu-ai/tool-wikipedia",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@sisu-ai/core": "1.1.1"
+        "@sisu-ai/core": "1.1.2"
       }
     },
     "packages/tools/wikipedia/node_modules/zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,9 +140,9 @@
       }
     },
     "examples/ollama-hello": {
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
-        "@sisu-ai/adapter-ollama": "4.0.2",
+        "@sisu-ai/adapter-ollama": "4.0.3",
         "@sisu-ai/core": "1.1.2",
         "@sisu-ai/mw-trace-viewer": "5.0.2",
         "@sisu-ai/mw-usage-tracker": "4.0.2",
@@ -160,9 +160,9 @@
       }
     },
     "examples/ollama-stream": {
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
-        "@sisu-ai/adapter-ollama": "4.0.2",
+        "@sisu-ai/adapter-ollama": "4.0.3",
         "@sisu-ai/core": "1.1.2",
         "dotenv": "^16.4.5"
       }
@@ -178,9 +178,9 @@
       }
     },
     "examples/ollama-vision": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@sisu-ai/adapter-ollama": "4.0.2",
+        "@sisu-ai/adapter-ollama": "4.0.3",
         "@sisu-ai/core": "1.1.2",
         "@sisu-ai/mw-trace-viewer": "5.0.2",
         "@sisu-ai/mw-usage-tracker": "4.0.2",
@@ -198,9 +198,9 @@
       }
     },
     "examples/ollama-weather": {
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
-        "@sisu-ai/adapter-ollama": "4.0.2",
+        "@sisu-ai/adapter-ollama": "4.0.3",
         "@sisu-ai/core": "1.1.2",
         "@sisu-ai/mw-control-flow": "4.0.2",
         "@sisu-ai/mw-conversation-buffer": "4.0.2",
@@ -234,9 +234,9 @@
       }
     },
     "examples/ollama-web-search": {
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
-        "@sisu-ai/adapter-ollama": "4.0.2",
+        "@sisu-ai/adapter-ollama": "4.0.3",
         "@sisu-ai/core": "1.1.2",
         "@sisu-ai/mw-conversation-buffer": "4.0.2",
         "@sisu-ai/mw-error-boundary": "4.0.2",
@@ -6312,7 +6312,7 @@
     },
     "packages/adapters/ollama": {
       "name": "@sisu-ai/adapter-ollama",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@sisu-ai/core": "1.1.2"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ex:openai:graph": "TRACE_HTML=1 npm run dev -w examples/openai-graph -- --trace",
     "ex:ollama:hello": "TRACE_HTML=1 npm run dev -w examples/ollama-hello -- --trace",
     "ex:ollama:weather": "TRACE_HTML=1 npm run dev -w examples/ollama-weather -- --trace",
+    "ex:ollama:vision": "TRACE_HTML=1 npm run dev -w examples/ollama-vision -- --trace",
     "ex:anthropic:stream": "TRACE_HTML=1 npm run dev -w examples/anthropic-stream -- --trace",
     "ex:openai:stream": "TRACE_HTML=1 npm run dev -w examples/openai-stream -- --trace",
     "ex:ollama:stream": "TRACE_HTML=1 npm run dev -w examples/ollama-stream -- --trace",

--- a/packages/adapters/ollama/CHANGELOG.md
+++ b/packages/adapters/ollama/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sisu-ai/adapter-ollama
 
+## 4.0.3
+
+### Patch Changes
+
+- 43e3b32: Add image content support matching OpenAI's `image_url` format.
+
 ## 4.0.2
 
 ### Patch Changes

--- a/packages/adapters/ollama/CHANGELOG.md
+++ b/packages/adapters/ollama/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sisu-ai/adapter-ollama
 
+## 4.1.0
+
+### Minor Changes
+
+- 9b419d0: Normalized Ollama image handling
+
 ## 4.0.3
 
 ### Patch Changes

--- a/packages/adapters/ollama/README.md
+++ b/packages/adapters/ollama/README.md
@@ -16,8 +16,6 @@ npm i @sisu-ai/adapter-ollama
 - Start Ollama locally: `ollama serve`
 - Pull a tools-capable model: `ollama pull llama3.1:latest`
 
-## Documentation
-Discover what you can do through examples or documentation. Check it out at https://github.com/finger-gun/sisu
 
 ## Usage
 ```ts
@@ -25,8 +23,29 @@ import { ollamaAdapter } from '@sisu-ai/adapter-ollama';
 
 const model = ollamaAdapter({ model: 'llama3.1' });
 // or with custom base URL: { baseUrl: 'http://localhost:11435' }
+```
 
-// Works with @sisu-ai/mw-tool-calling — tools are passed via GenerateOptions.tools
+## Images (Vision)
+- Accepts multi-part `content` arrays with `type: 'text' | 'image_url'` and convenience fields like `images`/`image_url`.
+- The adapter maps these to Ollama's expected shape by sending `content` as a string and `images` as a string array on the message.
+
+Content parts (adapter maps to `images[]` under the hood):
+```ts
+const messages: any[] = [
+  { role: 'user', content: [
+    { type: 'text', text: 'What is in this image?' },
+    { type: 'image_url', image_url: { url: 'https://example.com/pic.jpg' } },
+  ] }
+];
+const res = await model.generate(messages, { toolChoice: 'none' });
+```
+
+Convenience shape:
+```ts
+const messages: any[] = [
+  { role: 'user', content: 'Describe the image.', images: ['https://example.com/pic.jpg'] },
+];
+const res = await model.generate(messages, { toolChoice: 'none' });
 ```
 
 ## Tools

--- a/packages/adapters/ollama/package.json
+++ b/packages/adapters/ollama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sisu-ai/adapter-ollama",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/ollama/package.json
+++ b/packages/adapters/ollama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sisu-ai/adapter-ollama",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapters/ollama/src/index.ts
+++ b/packages/adapters/ollama/src/index.ts
@@ -7,7 +7,18 @@ export interface OllamaAdapterOptions {
   headers?: Record<string, string>;
 }
 
-type OllamaChatMessage = { role: 'system' | 'user' | 'assistant' | 'tool'; content?: string | null; name?: string; tool_call_id?: string; tool_calls?: any[] };
+type OllamaContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image_url'; image_url: { url: string } | string };
+
+type OllamaChatMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content?: string | null;
+  images?: string[];
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: any[];
+};
 
 export function ollamaAdapter(opts: OllamaAdapterOptions): LLM {
   const envBase = firstConfigValue(['OLLAMA_BASE_URL', 'BASE_URL']);
@@ -21,15 +32,28 @@ export function ollamaAdapter(opts: OllamaAdapterOptions): LLM {
     // Map messages to Ollama format; include assistant tool_calls and tool messages
     const mapped: OllamaChatMessage[] = messages.map((m: any) => {
       const base: any = { role: m.role };
-      if (m.role === 'assistant' && Array.isArray(m.tool_calls)) {
-        base.tool_calls = m.tool_calls.map((tc: any) => ({ id: tc.id, type: 'function', function: { name: tc.name, arguments: (tc.arguments ?? {}) } }));
-        base.content = m.content ? String(m.content) : null;
+      const anyM = m as Message & {
+        tool_calls?: Array<{ id?: string; name?: string; arguments?: unknown }>;
+        contentParts?: unknown;
+        images?: unknown;
+        image_urls?: unknown;
+        image_url?: unknown;
+        image?: unknown;
+      };
+      if (m.role === 'assistant' && Array.isArray(anyM.tool_calls)) {
+        base.tool_calls = anyM.tool_calls.map((tc: any) => ({ id: tc.id, type: 'function', function: { name: tc.name, arguments: (tc.arguments ?? {}) } }));
+        const ti = buildTextAndImages(anyM);
+        base.content = ti.content ?? (m.content !== undefined ? m.content : null);
+        if (ti.images?.length) base.images = ti.images;
       } else if (m.role === 'tool') {
         base.content = String(m.content ?? '');
         if (m.tool_call_id) base.tool_call_id = m.tool_call_id;
         if (m.name && !m.tool_call_id) base.name = m.name;
       } else {
-        base.content = String(m.content ?? '');
+        const ti = buildTextAndImages(anyM);
+        base.content = ti.content ?? (m.content ?? '');
+        if (ti.images?.length) base.images = ti.images;
+        if (m.name) base.name = m.name;
       }
       return base;
     });
@@ -103,11 +127,11 @@ export function ollamaAdapter(opts: OllamaAdapterOptions): LLM {
       }
       const data: any = raw ? JSON.parse(raw) : {};
       const choice = data?.message ?? {};
-      const content = choice?.content ?? '';
+      const content = choice?.content;
       const tcs = Array.isArray(choice?.tool_calls)
         ? choice.tool_calls.map((tc: any) => ({ id: tc.id, name: tc.function?.name, arguments: safeJson(tc.function?.arguments) }))
         : undefined;
-      const out: any = { role: 'assistant', content: String(content ?? '') };
+      const out: any = { role: 'assistant', content: content ?? '' };
       if (tcs) out.tool_calls = tcs;
       return { message: out };
     })();
@@ -156,4 +180,42 @@ function toJsonSchema(schema: any): any {
 function safeJson(s: any) {
   if (typeof s !== 'string') return s;
   try { return JSON.parse(s); } catch { return s; }
+}
+
+// Accept OpenAI-style content parts or convenience fields and map to
+// Ollama's expected shape: { content: string, images?: string[] }
+function buildTextAndImages(m: unknown): { content?: string; images?: string[] } {
+  if (!m || typeof m !== 'object') return {};
+  const obj = m as Record<string, unknown>;
+  // If content is parts, normalize
+  if (Array.isArray(obj.content) || Array.isArray(obj.contentParts)) {
+    const parts = Array.isArray(obj.content) ? (obj.content as unknown[]) : (obj.contentParts as unknown[]);
+    const texts: string[] = [];
+    const images: string[] = [];
+    for (const p of parts) {
+      if (typeof p === 'string') { texts.push(p); continue; }
+      if (!p || typeof p !== 'object') continue;
+      const po = p as Record<string, unknown>;
+      const t = po.type as string | undefined;
+      if (t === 'text' && typeof po.text === 'string') { texts.push(po.text); continue; }
+      if (t === 'image_url') {
+        const iu = po.image_url as unknown;
+        if (typeof iu === 'string') images.push(iu);
+        else if (iu && typeof iu === 'object' && typeof (iu as any).url === 'string') images.push(String((iu as any).url));
+        continue;
+      }
+      if (t === 'image' && typeof (po as any).url === 'string') { images.push(String((po as any).url)); continue; }
+      if (typeof (po as any).image_url === 'string') { images.push(String((po as any).image_url)); continue; }
+      if (typeof (po as any).image === 'string') { images.push(String((po as any).image)); continue; }
+    }
+    return { content: texts.join('\n\n'), images: images.length ? images : undefined };
+  }
+  // Otherwise, use content string (if any) and collect convenience images
+  const images: string[] = [];
+  if (Array.isArray(obj.images)) images.push(...(obj.images as string[]));
+  if (Array.isArray(obj.image_urls)) images.push(...(obj.image_urls as string[]));
+  if (typeof obj.image_url === 'string') images.push(obj.image_url);
+  if (typeof obj.image === 'string') images.push(obj.image);
+  const content = typeof obj.content === 'string' ? obj.content : undefined;
+  return { content, images: images.length ? images : undefined };
 }

--- a/packages/adapters/ollama/test/ollama.test.ts
+++ b/packages/adapters/ollama/test/ollama.test.ts
@@ -89,17 +89,28 @@ test('ollamaAdapter sends tools schema when provided', async () => {
   expect(body.tools[0].function.name).toBe('echo');
 });
 
-test('ollamaAdapter maps content parts or convenience images to Ollama images[]', async () => {
-  const fetchMock = vi.spyOn(globalThis, 'fetch' as any).mockResolvedValue({ ok: true, text: async () => JSON.stringify({ message: { role: 'assistant', content: '' } }) } as any);
+test('ollamaAdapter converts http image URLs to base64 images[]', async () => {
+  const imgBytes = new Uint8Array([1, 2, 3, 4]);
+  const imgB64 = Buffer.from(imgBytes).toString('base64'); // AQIDBA==
+  const fetchMock = vi.spyOn(globalThis, 'fetch' as any).mockImplementation(async (url: any, init: any) => {
+    const u = String(url);
+    if (u.includes('/api/chat')) {
+      return { ok: true, status: 200, statusText: 'OK', text: async () => JSON.stringify({ message: { role: 'assistant', content: '' } }) } as any;
+    }
+    // image fetch
+    return { ok: true, arrayBuffer: async () => imgBytes.buffer } as any;
+  });
   const llm = ollamaAdapter({ model: 'llama3' });
   const messages: Message[] = [
     { role: 'user', content: 'see', images: ['http://img/1.png', 'http://img/2.png'] } as any,
   ];
   await llm.generate(messages);
-  const [, init] = fetchMock.mock.calls[0] as any;
+  // Last call should be to /api/chat; inspect its body
+  const calls = fetchMock.mock.calls as any[];
+  const [, init] = calls.find(c => String(c[0]).includes('/api/chat')) as any;
   const body = JSON.parse(init.body);
   const user = body.messages[0];
   expect(typeof user.content).toBe('string');
   expect(Array.isArray(user.images)).toBe(true);
-  expect(user.images).toEqual(['http://img/1.png', 'http://img/2.png']);
+  expect(user.images).toEqual([imgB64, imgB64]);
 });

--- a/packages/adapters/openai/CHANGELOG.md
+++ b/packages/adapters/openai/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sisu-ai/adapter-openai
 
+## 4.1.0
+
+### Minor Changes
+
+- 9b419d0: Minor fixes
+
 ## 4.0.2
 
 ### Patch Changes

--- a/packages/adapters/openai/README.md
+++ b/packages/adapters/openai/README.md
@@ -70,7 +70,6 @@ const res = await model.generate(messages, { toolChoice: 'none' });
 - Images: Prefer `imagePer1K` (e.g., ≈0.217 per 1K images). Alternatively, use `imageInputPer1K` + `imageTokenPerImage`.
 
  
-
 ## Debugging
 - `DEBUG_LLM=1` prints sanitized payloads and error bodies.
 - Combine with `LOG_LEVEL=debug` to see middleware events.

--- a/packages/adapters/openai/package.json
+++ b/packages/adapters/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sisu-ai/adapter-openai",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
- Updated package.json to include a new example for Ollama vision.
- Enhanced README.md to document the new image handling capabilities and examples for using multi-part content.
- Modified index.ts to support OpenAI-style content parts, allowing for text and image URLs to be processed and mapped to Ollama's expected format.
- Implemented a utility function to build text and images from the provided message structure.
- Added a test case to verify that content parts and convenience images are correctly mapped to the Ollama adapter's image handling.